### PR TITLE
Feature/support live activity with apns2 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,11 @@ The Request body must have a notifications array. The following is a parameter t
 | mutable_content         | bool         | enable Notification Service app extension.                                                        | -        | only iOS(10.0+).                                              |
 | name                    | string       | sets the name value on the aps sound dictionary.                                                  | -        | only iOS                                                      |
 | volume                  | float32      | sets the volume value on the aps sound dictionary.                                                | -        | only iOS                                                      |
-| interruption_level      | string       | defines the interruption level for the push notification.                                         | -        | only iOS(15.0+)                                                      |
+| interruption_level      | string       | defines the interruption level for the push notification.                                         | -        | only iOS(15.0+)                                               |
+| content-state           | string array | dynamic and custom content for live-activity notification.                                        | -        | only iOS(16.1+)                                               |
+| timestamp               | int          | the UNIX time when sending the remote notification that updates or ends a Live Activity           | -        | only iOS(16.1+)                                               |                                            
+| event                   | string       | describes whether you update or end an ongoing Live Activity                                      | -        | only iOS(16.1+)                                               |     
+| stale-date              | int          | the date which a Live Activity becomes stale, or out of date                                      | -        | only iOS(16.1+)                                               |
 
 ### iOS alert payload
 

--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ The Request body must have a notifications array. The following is a parameter t
 | timestamp               | int          | the UNIX time when sending the remote notification that updates or ends a Live Activity           | -        | only iOS(16.1+)                                               |                                            
 | event                   | string       | describes whether you update or end an ongoing Live Activity                                      | -        | only iOS(16.1+)                                               |     
 | stale-date              | int          | the date which a Live Activity becomes stale, or out of date                                      | -        | only iOS(16.1+)                                               |
+| dismissal-date          | int          | the UNIX time -timestamp- which a Live Activity will end and will be removed                      | -        | only iOS(16.1+)                                               |
 
 ### iOS alert payload
 

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -12,6 +12,7 @@ import (
 	"github.com/appleboy/gorush/core"
 	"github.com/appleboy/gorush/logx"
 
+	"github.com/appleboy/go-fcm"
 	qcore "github.com/golang-queue/queue/core"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/msalihkarakasli/go-hms-push/push/model"
@@ -118,10 +119,13 @@ type PushNotification struct {
 
 	// ref: https://github.com/sideshow/apns2/blob/54928d6193dfe300b6b88dad72b7e2ae138d4f0a/payload/builder.go#L7-L24
 	InterruptionLevel string `json:"interruption_level,omitempty"`
-	ContentState      D      `json:"content-state,omitempty"`
-	StaleDate         int64  `json:"stale-date,omitempty"`
-	Event             string `json:"event,omitempty"`
-	Timestamp         int64  `json:"timestamp,omitempty"`
+
+	// live-activity support
+	// ref: https://developer.apple.com/documentation/activitykit/updating-and-ending-your-live-activity-with-activitykit-push-notifications
+	ContentState D      `json:"content-state,omitempty"`
+	StaleDate    int64  `json:"stale-date,omitempty"`
+	Event        string `json:"event,omitempty"`
+	Timestamp    int64  `json:"timestamp,omitempty"`
 }
 
 // Bytes for queue message

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -122,10 +122,11 @@ type PushNotification struct {
 
 	// live-activity support
 	// ref: https://developer.apple.com/documentation/activitykit/updating-and-ending-your-live-activity-with-activitykit-push-notifications
-	ContentState D      `json:"content-state,omitempty"`
-	StaleDate    int64  `json:"stale-date,omitempty"`
-	Event        string `json:"event,omitempty"`
-	Timestamp    int64  `json:"timestamp,omitempty"`
+	ContentState  D      `json:"content-state,omitempty"`
+	StaleDate     int64  `json:"stale-date,omitempty"`
+	DismissalDate int64  `json:"dismissal-date"`
+	Event         string `json:"event,omitempty"`
+	Timestamp     int64  `json:"timestamp,omitempty"`
 }
 
 // Bytes for queue message

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -12,7 +12,6 @@ import (
 	"github.com/appleboy/gorush/core"
 	"github.com/appleboy/gorush/logx"
 
-	"github.com/appleboy/go-fcm"
 	qcore "github.com/golang-queue/queue/core"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/msalihkarakasli/go-hms-push/push/model"
@@ -119,6 +118,10 @@ type PushNotification struct {
 
 	// ref: https://github.com/sideshow/apns2/blob/54928d6193dfe300b6b88dad72b7e2ae138d4f0a/payload/builder.go#L7-L24
 	InterruptionLevel string `json:"interruption_level,omitempty"`
+	ContentState      D      `json:"content-state,omitempty"`
+	StaleDate         int64  `json:"stale-date,omitempty"`
+	Event             string `json:"event,omitempty"`
+	Timestamp         int64  `json:"timestamp,omitempty"`
 }
 
 // Bytes for queue message

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -294,7 +294,7 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 		notificationPayload.AlertSummaryArgCount(req.Alert.SummaryArgCount)
 	}
 
-	// will wait for apns2 library update to reflect new methods
+	// will wait for apns2 library release to reflect new methods in live-activity
 	if len(req.ContentState) > 0 {
 		notificationPayload.ContentState(req.ContentState)
 	}

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -303,6 +303,10 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 		notificationPayload.StaleDate(req.StaleDate)
 	}
 
+	if req.DismissalDate > 0 {
+		notificationPayload.DismissalDate(req.DismissalDate)
+	}
+
 	if len(req.Event) > 0 {
 		notificationPayload.Event(req.Event)
 	}

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -294,7 +294,6 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 		notificationPayload.AlertSummaryArgCount(req.Alert.SummaryArgCount)
 	}
 
-	// will wait for apns2 library release to reflect new methods in live-activity
 	if len(req.ContentState) > 0 {
 		notificationPayload.ContentState(req.ContentState)
 	}

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -294,6 +294,23 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 		notificationPayload.AlertSummaryArgCount(req.Alert.SummaryArgCount)
 	}
 
+	// will wait for apns2 library update to reflect new methods
+	if len(req.ContentState) > 0 {
+		notificationPayload.ContentState(req.ContentState)
+	}
+
+	if req.StaleDate > 0 {
+		notificationPayload.StaleDate(req.StaleDate)
+	}
+
+	if len(req.Event) > 0 {
+		notificationPayload.Event(req.Event)
+	}
+
+	if req.Timestamp > 0 {
+		notificationPayload.Timestamp(req.Timestamp)
+	}
+
 	return notificationPayload
 }
 

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -516,6 +516,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	unix := time.Now().Unix()
 	stale_date := time.Now().Unix()
 	timeStamp := time.Now().Unix()
+	itemId := float64(12345)
 
 	req := &PushNotification{
 		Message: "Welcome",
@@ -535,12 +536,17 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 		StaleDate:         stale_date,
 		Event:             testMessage,
 		Timestamp:         timeStamp,
+		ContentState: D{
+			"item_id":   itemId,
+			"item_name": testMessage,
+		},
 	}
 
 	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
+	fmt.Println("data", string(dump))
 
 	if err := json.Unmarshal(data, &dat); err != nil {
 		log.Println(err)
@@ -563,10 +569,10 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	alert := aps["alert"].(map[string]interface{})
 	titleLocArgs := alert["title-loc-args"].([]interface{})
 	locArgs := alert["loc-args"].([]interface{})
+	contentSate := aps["content-state"].(map[string]interface{})
+	contentSateItemId := contentSate["item_id"]
+	contentSateItemName := contentSate["item_name"]
 
-	fmt.Println("data", json.Unmarshal(data, &dat))
-	fmt.Println("testMessage", event)
-	fmt.Println("sataleDate", staleDate)
 	assert.Equal(t, testMessage, action)
 	assert.Equal(t, testMessage, actionLocKey)
 	assert.Equal(t, testMessage, body)
@@ -579,6 +585,13 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	assert.Equal(t, testMessage, event)
 	assert.Equal(t, unix, staleDate)
 	assert.Equal(t, unix, timestamp)
+
+	// extensible contentState content
+	assert.Equal(t, contentSateItemId, itemId)
+	assert.Equal(t, contentSateItemName, testMessage)
+	assert.Contains(t, contentSate, "item_id")
+	assert.Contains(t, contentSate, "item_name")
+
 	assert.Contains(t, titleLocArgs, "a")
 	assert.Contains(t, titleLocArgs, "b")
 	assert.Contains(t, locArgs, "a")

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -2,14 +2,14 @@ package notify
 
 import (
 	"context"
+	"fmt"
+	"github.com/appleboy/gorush/config"
+	"github.com/appleboy/gorush/status"
 	"log"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
-
-	"github.com/appleboy/gorush/config"
-	"github.com/appleboy/gorush/status"
 
 	"github.com/buger/jsonparser"
 	"github.com/sideshow/apns2"
@@ -513,6 +513,9 @@ func TestMessageAndTitle(t *testing.T) {
 
 func TestIOSAlertNotificationStructure(t *testing.T) {
 	var dat map[string]interface{}
+	unix := time.Now().Unix()
+	stale_date := time.Now().Unix()
+	timeStamp := time.Now().Unix()
 
 	req := &PushNotification{
 		Message: "Welcome",
@@ -529,6 +532,9 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 			TitleLocKey:  testMessage,
 		},
 		InterruptionLevel: testMessage,
+		StaleDate:         stale_date,
+		Event:             testMessage,
+		Timestamp:         timeStamp,
 	}
 
 	notification := GetIOSNotification(req)
@@ -550,11 +556,17 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	subtitle, _ := jsonparser.GetString(data, "aps", "alert", "subtitle")
 	titleLocKey, _ := jsonparser.GetString(data, "aps", "alert", "title-loc-key")
 	interruptionLevel, _ := jsonparser.GetString(data, "aps", "interruption-level")
+	staleDate, _ := jsonparser.GetInt(data, "aps", "stale-date")
+	event, _ := jsonparser.GetString(data, "aps", "event")
+	timestamp, _ := jsonparser.GetInt(data, "aps", "timestamp")
 	aps := dat["aps"].(map[string]interface{})
 	alert := aps["alert"].(map[string]interface{})
 	titleLocArgs := alert["title-loc-args"].([]interface{})
 	locArgs := alert["loc-args"].([]interface{})
 
+	fmt.Println("data", json.Unmarshal(data, &dat))
+	fmt.Println("testMessage", event)
+	fmt.Println("sataleDate", staleDate)
 	assert.Equal(t, testMessage, action)
 	assert.Equal(t, testMessage, actionLocKey)
 	assert.Equal(t, testMessage, body)
@@ -564,6 +576,9 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	assert.Equal(t, testMessage, subtitle)
 	assert.Equal(t, testMessage, titleLocKey)
 	assert.Equal(t, testMessage, interruptionLevel)
+	assert.Equal(t, testMessage, event)
+	assert.Equal(t, unix, staleDate)
+	assert.Equal(t, unix, timestamp)
 	assert.Contains(t, titleLocArgs, "a")
 	assert.Contains(t, titleLocArgs, "b")
 	assert.Contains(t, locArgs, "a")

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -515,6 +515,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	var dat map[string]interface{}
 	unix := time.Now().Unix()
 	stale_date := time.Now().Unix()
+	dismissal_date := stale_date + 5
 	timeStamp := time.Now().Unix()
 	itemId := float64(12345)
 
@@ -534,6 +535,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 		},
 		InterruptionLevel: testMessage,
 		StaleDate:         stale_date,
+		DismissalDate: 	   dismissal_date
 		Event:             testMessage,
 		Timestamp:         timeStamp,
 		ContentState: D{
@@ -586,7 +588,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	assert.Equal(t, unix, staleDate)
 	assert.Equal(t, unix, timestamp)
 
-	// extensible contentState content
+	// dynamic contentState content
 	assert.Equal(t, contentSateItemId, itemId)
 	assert.Equal(t, contentSateItemName, testMessage)
 	assert.Contains(t, contentSate, "item_id")

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -2,14 +2,14 @@ package notify
 
 import (
 	"context"
-	"fmt"
-	"github.com/appleboy/gorush/config"
-	"github.com/appleboy/gorush/status"
 	"log"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/appleboy/gorush/config"
+	"github.com/appleboy/gorush/status"
 
 	"github.com/buger/jsonparser"
 	"github.com/sideshow/apns2"
@@ -535,7 +535,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 		},
 		InterruptionLevel: testMessage,
 		StaleDate:         stale_date,
-		DismissalDate: 	   dismissal_date
+		DismissalDate:     dismissal_date,
 		Event:             testMessage,
 		Timestamp:         timeStamp,
 		ContentState: D{
@@ -548,7 +548,6 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
-	fmt.Println("data", string(dump))
 
 	if err := json.Unmarshal(data, &dat); err != nil {
 		log.Println(err)
@@ -571,9 +570,9 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	alert := aps["alert"].(map[string]interface{})
 	titleLocArgs := alert["title-loc-args"].([]interface{})
 	locArgs := alert["loc-args"].([]interface{})
-	contentSate := aps["content-state"].(map[string]interface{})
-	contentSateItemId := contentSate["item_id"]
-	contentSateItemName := contentSate["item_name"]
+	contentState := aps["content-state"].(map[string]interface{})
+	contentStateItemId := contentState["item_id"]
+	contentStateItemName := contentState["item_name"]
 
 	assert.Equal(t, testMessage, action)
 	assert.Equal(t, testMessage, actionLocKey)
@@ -589,10 +588,10 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	assert.Equal(t, unix, timestamp)
 
 	// dynamic contentState content
-	assert.Equal(t, contentSateItemId, itemId)
-	assert.Equal(t, contentSateItemName, testMessage)
-	assert.Contains(t, contentSate, "item_id")
-	assert.Contains(t, contentSate, "item_name")
+	assert.Equal(t, contentStateItemId, itemId)
+	assert.Equal(t, contentStateItemName, testMessage)
+	assert.Contains(t, contentState, "item_id")
+	assert.Contains(t, contentState, "item_name")
 
 	assert.Contains(t, titleLocArgs, "a")
 	assert.Contains(t, titleLocArgs, "b")


### PR DESCRIPTION
GOAL: Support live activities notifications.

- Adds  support  payload to live-activity based on **apns2** library 

`dismissal-date`
`stale-date`
`timestamp`
`even`
`content-state`

- Fit in code implementations from https://github.com/GonzaloAvilez/apns2/pull/1/


- Updates readme re iOS 16 + live activity feature

## TESTS
test code coverage 
<img width="932" alt="image" src="https://github.com/GonzaloAvilez/gorush/assets/18094168/fc18e543-1a8b-4825-91e2-f324ea71749f">


manual testing with curl POST events using https://github.com/GonzaloAvilez/apns2/pull/1/ in current forked repository
![image](https://github.com/GonzaloAvilez/gorush/assets/18094168/6be41f5c-a1a7-45be-abbc-304529d8f442)


