### PR TITLE
fix(iOS): adapt payload naming variables according to latest relase of APNS2 

### DIFF
--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -295,23 +295,23 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 	}
 
 	if len(req.ContentState) > 0 {
-		notificationPayload.ContentState(req.ContentState)
+		notificationPayload.SetContentState(req.ContentState)
 	}
 
 	if req.StaleDate > 0 {
-		notificationPayload.StaleDate(req.StaleDate)
+		notificationPayload.SetStaleDate(req.StaleDate)
 	}
 
 	if req.DismissalDate > 0 {
-		notificationPayload.DismissalDate(req.DismissalDate)
+		notificationPayload.SetDismissalDate(req.DismissalDate)
 	}
 
 	if len(req.Event) > 0 {
-		notificationPayload.Event(req.Event)
+		notificationPayload.SetEvent(payload.ELiveActivityEvent(req.Event))
 	}
 
 	if req.Timestamp > 0 {
-		notificationPayload.Timestamp(req.Timestamp)
+		notificationPayload.SetTimestamp(req.Timestamp)
 	}
 
 	return notificationPayload


### PR DESCRIPTION
Adjust **APNS2** payload to func call by a convention with prefix of **Set**... defined in version 0.24.0 -> 
Reference to changes in library -> https://github.com/sideshow/apns2/pull/219/files